### PR TITLE
MAINT: Adapt to R115 dialog expression & pose changes

### DIFF
--- a/src/Modules/GuiRedraw.ts
+++ b/src/Modules/GuiRedraw.ts
@@ -106,17 +106,19 @@ export class GuiRedrawModule extends BaseModule {
         'DrawButton(1910, 145 + (A - CharacterAppearanceOffset) * 95, 65, 65, "", CanPickColor ? "%background" : "%disabled", CanPickColor ? ColorIsSimple ? "Icons/Small/ColorChange.png" : "Icons/Small/ColorChangeMulti.png" : "Icons/Small/ColorBlocked.png", null, !CanPickColor);',
     });
 
-    patchFunction('DialogDrawExpressionMenu', {
-      'const color = (expression == FE.CurrentExpression ? "Pink" : (!allowed ? "#888" : "White"));':
-        'const color = (expression == FE.CurrentExpression ? "%accent" : (!allowed ? "%disabled" : "%background"));',
-      'DrawButton(20, OffsetY, 90, 90, "", i == DialogFacialExpressionsSelected ? "Cyan" : "White", "Assets/Female3DCG/" + FE.Group + (FE.CurrentExpression ? "/" + FE.CurrentExpression : "") + "/Icon.png");':
-        'DrawButton(20, OffsetY, 90, 90, "", i == DialogFacialExpressionsSelected ? "%accent" : "%background", "Assets/Female3DCG/" + FE.Group + (FE.CurrentExpression ? "/" + FE.CurrentExpression : "") + "/Icon.png");'
-    });
+    if (GameVersion === 'R114') {
+      patchFunction('DialogDrawExpressionMenu', {
+        'const color = (expression == FE.CurrentExpression ? "Pink" : (!allowed ? "#888" : "White"));':
+          'const color = (expression == FE.CurrentExpression ? "%accent" : (!allowed ? "%disabled" : "%background"));',
+        'DrawButton(20, OffsetY, 90, 90, "", i == DialogFacialExpressionsSelected ? "Cyan" : "White", "Assets/Female3DCG/" + FE.Group + (FE.CurrentExpression ? "/" + FE.CurrentExpression : "") + "/Icon.png");':
+          'DrawButton(20, OffsetY, 90, 90, "", i == DialogFacialExpressionsSelected ? "%accent" : "%background", "Assets/Female3DCG/" + FE.Group + (FE.CurrentExpression ? "/" + FE.CurrentExpression : "") + "/Icon.png");'
+      });
 
-    patchFunction('DialogDrawPoseMenu', {
-      'DrawButton(offsetX, offsetY, 90, 90, "", !Player.CanChangeToPose(Name) ? "#888" : isActive ? "Pink" : "White", `Icons/Poses/${Name}.png`);':
-        'DrawButton(offsetX, offsetY, 90, 90, "", !Player.CanChangeToPose(Name) ? "%disabled" : isActive ? "%accent" : "%background", `Icons/Poses/${Name}.png`);',
-    });
+      patchFunction('DialogDrawPoseMenu', {
+        'DrawButton(offsetX, offsetY, 90, 90, "", !Player.CanChangeToPose(Name) ? "#888" : isActive ? "Pink" : "White", `Icons/Poses/${Name}.png`);':
+          'DrawButton(offsetX, offsetY, 90, 90, "", !Player.CanChangeToPose(Name) ? "%disabled" : isActive ? "%accent" : "%background", `Icons/Poses/${Name}.png`);',
+      });
+    }
 
     patchFunction('ExtendedItemGetButtonColor', {
       'ButtonColor = "#888888";':
@@ -197,14 +199,17 @@ export class GuiRedrawModule extends BaseModule {
     unpatchFuntion('DrawProcessScreenFlash');
     unpatchFuntion('ChatAdminRun');
     unpatchFuntion('AppearanceRun');
-    unpatchFuntion('DialogDrawExpressionMenu');
-    unpatchFuntion('DialogDrawPoseMenu');
+
     unpatchFuntion('ExtendedItemGetButtonColor');
     unpatchFuntion('PreferenceSubscreenDifficultyRun');
     unpatchFuntion('ChatAdminRoomCustomizationRun');
     unpatchFuntion('Shop2._AssetElementDraw');
     unpatchFuntion('RelogRun');
     unpatchFuntion('ChatRoomMenuDraw');
+    if (GameVersion === 'R114') {
+      unpatchFuntion('DialogDrawExpressionMenu');
+      unpatchFuntion('DialogDrawPoseMenu');
+    }
 
     this.patched = false;
   }


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5516](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5516)

Adapts Themed to the R115 changes for the left-most dialog side panels, converting them from canvas to DOM. In particularly relevant for Themed: this has resulted in the deprecation of `DialogDrawExpressionMenu()` and `DialogDrawPoseMenu()`, with the relevant button styling now being managed via the standard BC `.button-styling` CSS class.

Marking as draft until the upstream PR has been merged.